### PR TITLE
Fix issue w/ static assets not loading on GH Pages by adding assetPrefix field to Next config

### DIFF
--- a/apps/council-ui/next.config.js
+++ b/apps/council-ui/next.config.js
@@ -1,8 +1,9 @@
-// const withTM = require("next-transpile-modules")(["ui"]);
-// module.exports = withTM({
-//   reactStrictMode: true,
-// });
-
+/**
+ * @type {import('next').NextConfig}
+ */
 module.exports = {
   reactStrictMode: true,
+  // js chunks and css files should have "./" appended to them so that GitHub
+  // pages can resolve them.
+  assetPrefix: "./",
 };


### PR DESCRIPTION
**The Problem**

Github Pages cannot resolve the js chunks and css files in the `<head>` section because the asset paths are not relative.

<img width="674" alt="image" src="https://user-images.githubusercontent.com/4524175/199354551-d1f1028d-59c0-44f1-9131-816fd7eb26e1.png">



**The solution**
We add an asset prefix option so that we get relative paths when running `next build` and `next export`:

<img width="480" alt="image" src="https://user-images.githubusercontent.com/4524175/199354790-abb56516-d0cb-4914-947c-3d28f3c36bfd.png">

**More reading**
See: https://github.com/DaveAldon/Next.js-and-GitHub-Pages-Example
