### PR TITLE
Avoid boolean params

### DIFF
--- a/apps/council-ui/src/ui/utils/formatGSCStatus.ts
+++ b/apps/council-ui/src/ui/utils/formatGSCStatus.ts
@@ -1,10 +1,16 @@
 export type GSCStatus = "Idle" | "Member" | "Eligible" | "Ineligible";
 
-export function formatGSCStatus(
+interface GSCStatusOptions {
+  isIdle?: boolean;
+  isMember?: boolean;
+  isEligible?: boolean;
+}
+
+export function formatGSCStatus({
   isIdle = false,
   isMember = false,
   isEligible = false,
-): GSCStatus {
+}: GSCStatusOptions = {}): GSCStatus {
   if (isIdle) {
     return "Idle";
   }

--- a/apps/council-ui/src/ui/voter/hooks/useFormattedGSCStatus.ts
+++ b/apps/council-ui/src/ui/voter/hooks/useFormattedGSCStatus.ts
@@ -15,7 +15,7 @@ export function useFormattedGSCStatus(
       const isMember = await gscVoting?.getIsMember(address as string);
       const isEligible = await gscVoting?.getIsEligible(address as string);
 
-      return formatGSCStatus(isIdle, isMember, isEligible);
+      return formatGSCStatus({ isIdle, isMember, isEligible });
     },
   });
 }

--- a/apps/council-ui/src/ui/voter/utils/getFormattedGSCStatus.ts
+++ b/apps/council-ui/src/ui/voter/utils/getFormattedGSCStatus.ts
@@ -9,5 +9,5 @@ export async function getFormattedGSCStatus(
   const isMember = await gscVoting?.getIsMember(address as string);
   const isEligible = await gscVoting?.getIsEligible(address as string);
 
-  return formatGSCStatus(isIdle, isMember, isEligible);
+  return formatGSCStatus({ isIdle, isMember, isEligible });
 }


### PR DESCRIPTION
Boolean function params are a common code smell: https://martinfowler.com/bliki/FlagArgument.html

The quick and dirty solution is to just have named params here, though a more robust solution would be a `getGSCStatus` method, probably in the sdk, that can return the appropriate string.

