### PR TITLE
Add link to voting token for locking vault

### DIFF
--- a/apps/council-ui/src/ui/vaults/LockingVaultDetails.tsx
+++ b/apps/council-ui/src/ui/vaults/LockingVaultDetails.tsx
@@ -11,9 +11,11 @@ import { formatUnits } from "ethers/lib/utils";
 import { ReactElement } from "react";
 import toast from "react-hot-toast";
 import { councilConfigs } from "src/config/council.config";
+import { makeEtherscanAddressURL } from "src/lib/etherscan/makeEtherscanAddressURL";
 import { ErrorMessage } from "src/ui/base/error/ErrorMessage";
 import { formatAddress } from "src/ui/base/formatting/formatAddress";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import ExternalLink from "src/ui/base/links/ExternalLink";
 import { Page } from "src/ui/base/Page";
 import { Progress } from "src/ui/base/Progress";
 import { useCouncil } from "src/ui/council/useCouncil";
@@ -111,6 +113,19 @@ export function LockingVaultDetails({
                 </div>
               </div>
             )}
+
+            <div className="daisy-stats">
+              <div className="daisy-stat bg-base-300">
+                <div className="daisy-stat-title">Vault token</div>
+                <div className="daisy-stat-value text-sm">
+                  <ExternalLink
+                    href={makeEtherscanAddressURL(data.tokenAddress)}
+                  >
+                    {data.tokenSymbol}
+                  </ExternalLink>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div className="flex h-48 w-full flex-col gap-8 sm:flex-row">
@@ -154,6 +169,7 @@ interface LockingVaultDetailsData {
   descriptionURL: string | undefined;
   name: string | undefined;
   participants: number;
+  tokenAddress: string;
   tokenAllowance: string;
   tokenBalance: string;
   tokenSymbol: string;
@@ -196,6 +212,7 @@ function useLockingVaultDetailsData(
           100,
         accountVotingPower,
 
+        tokenAddress: token.address,
         tokenSymbol: await token.getSymbol(),
         tokenBalance: await token.getBalanceOf(account as string),
         tokenAllowance: await token.getAllowance(account as string, address),

--- a/apps/council-ui/src/ui/vaults/VestingVaultDetails.tsx
+++ b/apps/council-ui/src/ui/vaults/VestingVaultDetails.tsx
@@ -10,9 +10,11 @@ import { Signer } from "ethers";
 import { ReactElement } from "react";
 import index from "react-hot-toast";
 import { councilConfigs } from "src/config/council.config";
+import { makeEtherscanAddressURL } from "src/lib/etherscan/makeEtherscanAddressURL";
 import { ErrorMessage } from "src/ui/base/error/ErrorMessage";
 import { formatAddress } from "src/ui/base/formatting/formatAddress";
 import { formatBalance } from "src/ui/base/formatting/formatBalance";
+import ExternalLink from "src/ui/base/links/ExternalLink";
 import { Page } from "src/ui/base/Page";
 import { Progress } from "src/ui/base/Progress";
 import { useCouncil } from "src/ui/council/useCouncil";
@@ -105,6 +107,18 @@ export function VestingVaultDetails({
                 </div>
               </div>
             )}
+            <div className="daisy-stats">
+              <div className="daisy-stat bg-base-300">
+                <div className="daisy-stat-title">Vault token</div>
+                <div className="daisy-stat-value text-sm">
+                  <ExternalLink
+                    href={makeEtherscanAddressURL(data.tokenAddress)}
+                  >
+                    {data.tokenSymbol}
+                  </ExternalLink>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div className="flex h-48 w-full flex-col gap-x-8 sm:flex-row">
@@ -136,6 +150,7 @@ interface VestingVaultDetailsData {
   grantBalance: string;
   name: string | undefined;
   participants: number;
+  tokenAddress: string;
   tokenBalance: string;
   tokenSymbol: string;
   unlockDate: Date;
@@ -174,6 +189,7 @@ function useVestingVaultDetailsData(
       }
 
       return {
+        tokenAddress: token.address,
         tokenSymbol: await token.getSymbol(),
         tokenBalance: await token.getBalanceOf(account as string),
         // TODO: Confirm this is accurate.


### PR DESCRIPTION
Add a link to view the voting token on etherscan. 
- This will make demoing easier, as everyone can just click the link and go mint some voting tokens.
- Better visibility into the voting token itself in general, ie: see the token transfer history easily, etc..

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/4524175/206277280-beb6b931-6898-428d-a623-5ee7e146410c.png">
