### PR TITLE
Use progress bars for displaying quorum on proposals list

### DIFF
--- a/apps/council-ui/pages/proposals/index.tsx
+++ b/apps/council-ui/pages/proposals/index.tsx
@@ -8,7 +8,6 @@ import Skeleton from "react-loading-skeleton";
 import { makeEtherscanAddressURL } from "src/lib/etherscan/makeEtherscanAddressURL";
 import { makeProposalURL } from "src/routes";
 import { formatAddress } from "src/ui/base/formatting/formatAddress";
-import { formatBalance } from "src/ui/base/formatting/formatBalance";
 import { ExternalInfoCard } from "src/ui/base/information/ExternalInfoCard";
 import { ChevronRightSVG } from "src/ui/base/svg/ChevronRight";
 import { DownArrowSVG } from "src/ui/base/svg/DownArrow";
@@ -210,12 +209,15 @@ function ProposalTableRow({
       <td>{created?.toLocaleDateString() ?? "🤷"}</td>
       <td>{votingEnds?.toLocaleDateString() ?? "🤷"}</td>
       <td>
-        {requiredQuorum
-          ? `${formatBalance(currentQuorum, 0)} / ${formatBalance(
-              requiredQuorum,
-              0,
-            )} `
-          : "🤷"}
+        {requiredQuorum ? (
+          <progress
+            className="w-full daisy-progress daisy-progress-info bg-neutral"
+            value={currentQuorum}
+            max={requiredQuorum}
+          />
+        ) : (
+          "🤷"
+        )}
       </td>
       <td>{ballot ?? "🤷"}</td>
       <th>


### PR DESCRIPTION
The specific values are harder to parse and less important at the list view, especially if most proposals end up having the same quorum requirement. A proposal bar will make it easier to scan and quickly get a sense for how close it is.

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/3289505/211480829-00b4d683-3a81-477b-bded-fe0d3602a14f.png">
