### PR TITLE
Fix tooltips in production

### DIFF
--- a/apps/council-ui/next.config.js
+++ b/apps/council-ui/next.config.js
@@ -15,6 +15,12 @@ module.exports = (phase) => {
   // Production Config
   return {
     reactStrictMode: true,
+
+    // The default Next 13 minifier has a bug which makes react-tooltip not work
+    // in production environments. Turn this off. See:
+    // https://github.com/ReactTooltip/react-tooltip/issues/933
+    swcMinify: false,
+
     basePath: process.env.NEXT_PUBLIC_COUNCIL_UI_BASE_PATH ?? "",
   };
 };


### PR DESCRIPTION
The default Next 13 minifier has a bug which fails to compile react-tooltip correctly. 

This means tooltips would work in dev (because we don't minify in dev), but would throw a cryptic minified error in production environments, i.e.: `next build; next start` or `next export`.
<img width="496" alt="image" src="https://user-images.githubusercontent.com/4524175/216515282-ce991725-b29b-4391-b57c-705f4e767b34.png">

This solution comes from https://github.com/ReactTooltip/react-tooltip/issues/933