### PR TITLE
Fix bug in VoterAddress, only show icons when the address is your delegate

### DIFF
--- a/apps/council-ui/src/ui/voters/VoterAddress.tsx
+++ b/apps/council-ui/src/ui/voters/VoterAddress.tsx
@@ -32,7 +32,7 @@ export function VoterAddress({
   const allVaults = getAllVaultConfigs(chainId);
   const vaultNames = allVaults
     .map((vaultConfig) => {
-      if (delegatesByVault?.[vaultConfig.address]) {
+      if (delegatesByVault?.[vaultConfig.address]?.address === address) {
         return vaultConfig.name;
       }
     })


### PR DESCRIPTION
Impersonating Greg's account, I can see that he's his own delegate in the locking vault.

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/4524175/216885092-4992d8bb-5fab-4a09-82f1-cb0cc30472f4.png">
