### PR TITLE
[Vault] Disable delegate button when user has no balance

### DIFF
--- a/apps/council-ui/src/ui/vaults/ChangeDelegateForm.tsx
+++ b/apps/council-ui/src/ui/vaults/ChangeDelegateForm.tsx
@@ -6,22 +6,30 @@ import { makeVoterURL } from "src/routes";
 import { useDisplayName } from "src/ui/base/formatting/useDisplayName";
 import { Input } from "src/ui/base/forms/Input";
 import { VoterAddress } from "src/ui/voters/VoterAddress";
+import { useSigner } from "wagmi";
 
 interface ChangeDelegateFormProps {
   currentDelegate: string;
   onDelegate: (delegate: string) => void;
-  disabled?: boolean;
+  depositedBalance: string;
 }
 
 export function ChangeDelegateForm({
   currentDelegate,
   onDelegate,
-  disabled = false,
+  depositedBalance,
 }: ChangeDelegateFormProps): ReactElement {
+  const { data: signer } = useSigner();
   const [newDelegate, setNewDelegate] = useState("");
   const delegateName = useDisplayName(currentDelegate);
   const isDelegateZeroAddress =
     currentDelegate === ethers.constants.AddressZero;
+
+  const disabled = !signer || !+depositedBalance;
+  let buttonLabel = "Delegate";
+  if (!+depositedBalance) {
+    buttonLabel = "No voting power to delegate";
+  }
 
   return (
     <div className="flex flex-col p-4 basis-1/2 gap-y-4 daisy-card bg-base-300 h-fit">
@@ -55,7 +63,7 @@ export function ChangeDelegateForm({
         onClick={() => onDelegate(newDelegate)}
         disabled={disabled}
       >
-        Delegate
+        {buttonLabel}
       </button>
     </div>
   );

--- a/apps/council-ui/src/ui/vaults/frozenLockingVault/FrozenLockingVaultDetails.tsx
+++ b/apps/council-ui/src/ui/vaults/frozenLockingVault/FrozenLockingVaultDetails.tsx
@@ -26,8 +26,8 @@ interface LockingVaultDetailsProps {
 export function FrozenLockingVaultDetails({
   address,
 }: LockingVaultDetailsProps): ReactElement {
-  const { address: account } = useAccount();
   const { data: signer } = useSigner();
+  const { address: account } = useAccount();
   const { data, status, error } = useFrozenLockingVaultDetailsData(
     address,
     account,
@@ -64,7 +64,7 @@ export function FrozenLockingVaultDetails({
         {status === "success" ? (
           <ChangeDelegateForm
             currentDelegate={data.delegate || ethers.constants.AddressZero}
-            disabled={!signer || !+data.accountVotingPower}
+            depositedBalance={data.depositedBalance}
             onDelegate={(delegate) =>
               changeDelegate({ signer: signer as Signer, delegate })
             }

--- a/apps/council-ui/src/ui/vaults/lockingVault/LockingVaultDetails.tsx
+++ b/apps/council-ui/src/ui/vaults/lockingVault/LockingVaultDetails.tsx
@@ -110,7 +110,7 @@ export function LockingVaultDetails({
         {status === "success" ? (
           <ChangeDelegateForm
             currentDelegate={data.delegate || ethers.constants.AddressZero}
-            disabled={!signer || !+data.accountVotingPower}
+            depositedBalance={data.depositedBalance}
             onDelegate={handleDelegate}
           />
         ) : (

--- a/apps/council-ui/src/ui/vaults/vestingVault/VestingVaultDetails.tsx
+++ b/apps/council-ui/src/ui/vaults/vestingVault/VestingVaultDetails.tsx
@@ -74,7 +74,7 @@ export function VestingVaultDetails({
         {status === "success" && (
           <ChangeDelegateForm
             currentDelegate={data.delegate || ethers.constants.AddressZero}
-            disabled={!signer || !+data.accountVotingPower}
+            depositedBalance={data.grantBalance}
             onDelegate={(delegate) =>
               changeDelegate({ signer: signer as Signer, delegate })
             }


### PR DESCRIPTION
You can't delegate away someone else's VP they've delegated to you, therefore "Change Delegate" should be disabled when you don't have a deposited balance.

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/4524175/217150539-d10a43b9-44e4-443b-9b6a-b4dd1e689771.png">
