### PR TITLE
[Vaults] Consistent info card widths

### DIFF
--- a/apps/council-ui/src/ui/base/information/ExternalInfoCard.tsx
+++ b/apps/council-ui/src/ui/base/information/ExternalInfoCard.tsx
@@ -13,7 +13,7 @@ export function ExternalInfoCard({
   href,
 }: ExternalInfoCardProps): ReactElement {
   return (
-    <div className="p-4 border border-gray-300 rounded-xl w-fit hover:opacity-50 cursor-pointer select-text">
+    <div className="p-4 border border-gray-300 rounded-xl w-fit hover:opacity-50 cursor-pointer select-text flex-1">
       <div className="mb-1">
         <a href={href}>
           <h2 className="font-bold whitespace-nowrap">

--- a/apps/council-ui/src/ui/vaults/GenericVaultCard.tsx
+++ b/apps/council-ui/src/ui/vaults/GenericVaultCard.tsx
@@ -22,7 +22,7 @@ export function GenericVaultCard({
 }: GenericVaultCardProps): ReactElement {
   return (
     <Link href={makeVaultURL(address)}>
-      <div className="w-full sm:w-80 sm:h-72 daisy-card bg-base-300 hover:shadow-xl transition-shadow">
+      <div className="w-80 h-72 daisy-card bg-base-300 hover:shadow-xl transition-shadow">
         <div className="daisy-card-body justify-between">
           <div>
             <h2 className="text-2xl daisy-card-title">{name}</h2>

--- a/apps/council-ui/src/ui/vaults/gscVault/GSCVaultPreviewCard/GSCVaultPreviewCard.tsx
+++ b/apps/council-ui/src/ui/vaults/gscVault/GSCVaultPreviewCard/GSCVaultPreviewCard.tsx
@@ -35,7 +35,7 @@ export function GSCVaultPreviewCard({
         gscVaultPreviewCardData;
       return (
         <Link href={makeVaultURL(vaultAddress)}>
-          <div className="w-full sm:w-80 sm:h-72 daisy-card bg-base-300 hover:shadow-xl transition-shadow">
+          <div className="w-80 h-72 daisy-card bg-base-300 hover:shadow-xl transition-shadow ">
             <div className="daisy-card-body justify-between">
               <div>
                 <h2 className="daisy-card-title text-2xl ">{vaultName}</h2>


### PR DESCRIPTION
The two more info cards beneath the vaults are now same width. While here I also made the cards fixed dimensions.

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/4524175/217154334-c828e832-69ee-4b20-bd7f-dc800f973760.png">

<img width="454" alt="image" src="https://user-images.githubusercontent.com/4524175/217155533-52b4b39f-3571-4e4a-b5b9-a1616cda4dde.png">
