### PR TITLE
Add overload to fix build

### DIFF
--- a/apps/council-ui/pages/proposals/details.tsx
+++ b/apps/council-ui/pages/proposals/details.tsx
@@ -315,8 +315,10 @@ function useProposalDetailsPageData(
 }
 
 /**
- * Dedupe a list of votes by only keeping the latest instance
+ * Dedupe a list of votes by only keeping the latest instance.
  */
+// TODO: This function breaks the build when only the generic signature is used.
+// The overload signature fixes the build and maintains a strong return type.
 function dedupeVotes<T extends Vote[] | undefined>(votes: T): T;
 function dedupeVotes(votes: Vote[] | undefined): Vote[] | undefined {
   if (!votes) {


### PR DESCRIPTION
My last PR broke the build. I don't fully understand the problem since it lints ok and VS code gives no errors, but moving the generic to an overload fixes the build and maintains strong return types.