### PR TITLE
Redirect back to list pages instead of 404

### DIFF
--- a/apps/council-ui/pages/proposals/details.tsx
+++ b/apps/council-ui/pages/proposals/details.tsx
@@ -77,9 +77,13 @@ export default function ProposalPage(): ReactElement {
     return vote(voteArgs);
   };
 
-  if (!votingContractAddressParam || !idParam) {
-    replace("/404");
-    // User will go to 404 page if this block is reached
+  const { coreVoting, gscVoting } = useCouncil();
+  if (
+    ![coreVoting.address, gscVoting?.address].includes(votingContractAddress) ||
+    !votingContractAddressParam ||
+    !idParam
+  ) {
+    replace("/proposals");
     // Returning empty fragment is to remove the undefined type from the query params.
     return <></>;
   }

--- a/apps/council-ui/pages/vaults/details.tsx
+++ b/apps/council-ui/pages/vaults/details.tsx
@@ -20,7 +20,7 @@ export default function Vault(): ReactElement {
   const vaultConfig = allVaults.find((vault) => vault.address === address);
 
   if (!address || !vaultConfig) {
-    replace("/404");
+    replace("/vaults");
   }
 
   return (


### PR DESCRIPTION
Redirect to the list page instead of 404 when you switch networks on a proposal or vault page.