### PR TITLE
Add type field to some data sources for better registering

### DIFF
--- a/packages/council-sdk/src/datasources/votingVault/GSCVaultContractDataSource.ts
+++ b/packages/council-sdk/src/datasources/votingVault/GSCVaultContractDataSource.ts
@@ -5,12 +5,21 @@ import { CouncilContext } from "src/context/context";
 import { TransactionOptions } from "src/datasources/base/contract/ContractDataSource";
 import { VotingVaultContractDataSource } from "./VotingVaultContractDataSource";
 
+const TYPE = "GSCVault";
+
 /**
  * A DataSource with methods for making cached calls to a `GSCVault` contract
  * from the Council protocol.
  * @category Data Sources
  */
 export class GSCVaultContractDataSource extends VotingVaultContractDataSource<GSCVault> {
+  /**
+   * A field that can be used for more specific filtering when registering an
+   * instance of this data source with the council context.
+   */
+  static type = TYPE;
+  type = TYPE;
+
   constructor(address: string, context: CouncilContext) {
     super(GSCVault__factory.connect(address, context.provider), context);
   }

--- a/packages/council-sdk/src/datasources/votingVault/LockingVaultContractDataSource.ts
+++ b/packages/council-sdk/src/datasources/votingVault/LockingVaultContractDataSource.ts
@@ -7,12 +7,21 @@ import { TransactionOptions } from "src/datasources/base/contract/ContractDataSo
 import { TokenDataSource } from "src/datasources/token/TokenDataSource";
 import { VotingVaultContractDataSource } from "./VotingVaultContractDataSource";
 
+const TYPE = "LockingVault";
+
 /**
  * A DataSource with methods for making cached calls to a `LockingVault`
  * contract from the Council protocol.
  * @category Data Sources
  */
 export class LockingVaultContractDataSource extends VotingVaultContractDataSource<LockingVault> {
+  /**
+   * A field that can be used for more specific filtering when registering an
+   * instance of this data source with the council context.
+   */
+  static type = TYPE;
+  type = TYPE;
+
   constructor(address: string, context: CouncilContext) {
     super(LockingVault__factory.connect(address, context.provider), context);
     this.context = context;

--- a/packages/council-sdk/src/datasources/votingVault/VestingVaultContractDataSource.ts
+++ b/packages/council-sdk/src/datasources/votingVault/VestingVaultContractDataSource.ts
@@ -5,6 +5,8 @@ import { CouncilContext } from "src/context/context";
 import { TransactionOptions } from "src/datasources/base/contract/ContractDataSource";
 import { VotingVaultContractDataSource } from "./VotingVaultContractDataSource";
 
+const TYPE = "VestingVault";
+
 /**
  * A DataSource with methods for making cached calls to a `VestingVault`
  * contract from the Council protocol.
@@ -12,6 +14,13 @@ import { VotingVaultContractDataSource } from "./VotingVaultContractDataSource";
  */
 
 export class VestingVaultContractDataSource extends VotingVaultContractDataSource<VestingVault> {
+  /**
+   * A field that can be used for more specific filtering when registering an
+   * instance of this data source with the council context.
+   */
+  static type = TYPE;
+  type = TYPE;
+
   /**
    * Create a new `VestingVaultContractDataSource` instance.
    * @param vault - A `VestingVault` instance from the `@council/typechain`

--- a/packages/council-sdk/src/models/votingVault/GSCVault.ts
+++ b/packages/council-sdk/src/models/votingVault/GSCVault.ts
@@ -27,7 +27,7 @@ export class GSCVault extends VotingVault<GSCVaultContractDataSource> {
       dataSource:
         options?.dataSource ??
         context.registerDataSource(
-          { address },
+          { address, type: GSCVaultContractDataSource.type },
           new GSCVaultContractDataSource(address, context),
         ),
     });

--- a/packages/council-sdk/src/models/votingVault/LockingVault.ts
+++ b/packages/council-sdk/src/models/votingVault/LockingVault.ts
@@ -29,7 +29,7 @@ export class LockingVault extends VotingVault<LockingVaultContractDataSource> {
       dataSource:
         options?.dataSource ??
         context.registerDataSource(
-          { address },
+          { address, type: LockingVaultContractDataSource.type },
           new LockingVaultContractDataSource(address, context),
         ),
     });

--- a/packages/council-sdk/src/models/votingVault/VestingVault.ts
+++ b/packages/council-sdk/src/models/votingVault/VestingVault.ts
@@ -32,7 +32,7 @@ export class VestingVault extends VotingVault<VestingVaultContractDataSource> {
       dataSource:
         options?.dataSource ??
         context.registerDataSource(
-          { address },
+          { address, type: VestingVaultContractDataSource.type },
           new VestingVaultContractDataSource(address, context),
         ),
     });


### PR DESCRIPTION
If a generic `VotingVault` instance was created, it registered a `VotingVaultContactDataSource` with the `CouncilContext`. Then later if a `LockingVault` instance was created with the same address, it would try to register a `LockingVaultContractDataSource` using the same filter as the `VotingVault` which would just return the previously registered generic `VotingVaultContactDataSource`.

To fix this, I've added a `type` field to some of the data sources which are more specific versions of others so that the models can create more specific filters for them when registering.

**Example:**

```ts
// BEFORE

const address = '0x0'
const votingVault = new VotingVault(address, context)
const lockingVault = new LockingVault(address, context)

console.log(votingVault.dataSource === lockingVault.dataSource) // true

// this would throw an error since this method doesn't
// exist on the generic `VotingVaultContractDataSource`
lockingVault.getToken()

// AFTER

const address = '0x1'
const votingVault = new VotingVault(address, context)
const lockingVault = new LockingVault(address, context)

console.log(votingVault.dataSource === lockingVault.dataSource) // false

// works fine
lockingVault.getToken()

// ALSO

const address = '0x2'
// more specific created first
const lockingVault = new LockingVault(address, context)
const votingVault = new VotingVault(address, context)

console.log(votingVault.dataSource === lockingVault.dataSource) // true
```
