### PR TITLE
Show skeleton proposal title instead of fallback title

### DIFF
--- a/apps/council-ui/pages/proposals/details.tsx
+++ b/apps/council-ui/pages/proposals/details.tsx
@@ -94,7 +94,7 @@ export default function ProposalPage(): ReactElement {
     return <ErrorMessage error={error} />;
   }
 
-  const proposalTitle = getProposalTitle(data, status, id);
+  const proposalTitle = data?.title ?? `Proposal ${id}`;
 
   return (
     <Page>
@@ -109,7 +109,13 @@ export default function ProposalPage(): ReactElement {
         )}
         <div className="flex flex-col w-full md:flex-row gap-y-8">
           <div className="flex flex-col w-full md:max-w-lg">
-            <h1 className="mb-1 text-4xl font-bold w-full">{proposalTitle}</h1>
+            <h1 className="mb-1 text-4xl font-bold w-full">
+              {status === "loading" ? (
+                <Skeleton className="w-full h-16" />
+              ) : (
+                proposalTitle
+              )}
+            </h1>
             {data?.descriptionURL && (
               <ExternalLink href={data.descriptionURL} iconSize={18}>
                 Learn more about this proposal
@@ -225,22 +231,6 @@ interface ProposalDetailsPageData {
   title?: string;
   paragraphSummary: string | null;
   executedTransactionHash: string | null;
-}
-
-function getProposalTitle(
-  data: ProposalDetailsPageData | undefined,
-  status: "error" | "success" | "loading",
-  id: number,
-) {
-  if (status === "loading") {
-    return <Skeleton className="w-full h-16" />;
-  }
-
-  if (data?.title) {
-    return data.title;
-  }
-
-  return `Proposal ${id}`;
 }
 
 function useProposalDetailsPageData(

--- a/apps/council-ui/pages/proposals/details.tsx
+++ b/apps/council-ui/pages/proposals/details.tsx
@@ -94,18 +94,22 @@ export default function ProposalPage(): ReactElement {
     return <ErrorMessage error={error} />;
   }
 
-  const proposalTitle = data?.title ?? `Proposal ${id}`;
+  const proposalTitle = getProposalTitle(data, status, id);
 
   return (
     <Page>
       <div className="space-y-2">
-        <Breadcrumbs
-          crumbs={[{ href: Routes.PROPOSALS, content: "All proposals" }]}
-          currentPage={proposalTitle}
-        />
+        {status === "loading" ? (
+          <Skeleton containerClassName="block w-1/3" />
+        ) : (
+          <Breadcrumbs
+            crumbs={[{ href: Routes.PROPOSALS, content: "All proposals" }]}
+            currentPage={proposalTitle}
+          />
+        )}
         <div className="flex flex-col w-full md:flex-row gap-y-8">
-          <div className="flex flex-col md:max-w-lg">
-            <h1 className="mb-1 text-4xl font-bold">{proposalTitle}</h1>
+          <div className="flex flex-col w-full md:max-w-lg">
+            <h1 className="mb-1 text-4xl font-bold w-full">{proposalTitle}</h1>
             {data?.descriptionURL && (
               <ExternalLink href={data.descriptionURL} iconSize={18}>
                 Learn more about this proposal
@@ -221,6 +225,22 @@ interface ProposalDetailsPageData {
   title?: string;
   paragraphSummary: string | null;
   executedTransactionHash: string | null;
+}
+
+function getProposalTitle(
+  data: ProposalDetailsPageData | undefined,
+  status: "error" | "success" | "loading",
+  id: number,
+) {
+  if (status === "loading") {
+    return <Skeleton className="w-full h-16" />;
+  }
+
+  if (data?.title) {
+    return data.title;
+  }
+
+  return `Proposal ${id}`;
 }
 
 function useProposalDetailsPageData(


### PR DESCRIPTION
Previously the title would show "Proposal 1" as a fallback while the page data was loading. This was causing a weird label change flash. Now we just show a skeleton until we know for sure what label to display.

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/4524175/228890821-830d7d7b-c99c-441a-9b64-e4a7921961eb.png">
