### PR TITLE
Add more mainnet and localhost commands to council-deploy

### DIFF
--- a/apps/council-ui/src/config/council.config.ts
+++ b/apps/council-ui/src/config/council.config.ts
@@ -1,10 +1,12 @@
 import { CouncilConfig } from "src/config/CouncilConfig";
 import { goerliCouncilConfig } from "src/config/goerli";
+import { localhostCouncilConfig } from "src/config/localhost";
 import { mainnetCouncilConfig } from "src/config/mainnet";
 
-export type SupportedChainId = 1 | 5;
+export type SupportedChainId = 1 | 5 | 31337;
 
 export const councilConfigs: Record<SupportedChainId, CouncilConfig> = {
   1: mainnetCouncilConfig,
   5: goerliCouncilConfig,
+  31337: localhostCouncilConfig,
 };

--- a/apps/council-ui/src/config/localhost.ts
+++ b/apps/council-ui/src/config/localhost.ts
@@ -1,0 +1,44 @@
+import { CouncilConfig } from "src/config/CouncilConfig";
+
+export const localhostCouncilConfig: CouncilConfig = {
+  version: "",
+  chainId: 31337,
+  timelock: {
+    address: "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+  },
+  coreVoting: {
+    name: "Core Voting",
+    address: "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+    descriptionURL: "https://moreinfo.com",
+    vaults: [
+      {
+        name: "Locking Vault",
+        address: "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
+        type: "LockingVault",
+        descriptionURL: "https://moreinfo.com",
+      },
+      {
+        name: "Vesting Vault",
+        address: "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
+        type: "VestingVault",
+        descriptionURL: "https://moreinfo.com",
+      },
+    ],
+    proposals: {},
+  },
+
+  gscVoting: {
+    name: "GSC",
+    address: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+    descriptionURL: "https://moreinfo.com",
+    vaults: [
+      {
+        name: "GSC Vault",
+        address: "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE",
+        type: "GSCVault",
+        descriptionURL: "https://moreinfo.com",
+      },
+    ],
+    proposals: {},
+  },
+};

--- a/apps/council-ui/src/etherscan/makeEtherscanAddressURL.ts
+++ b/apps/council-ui/src/etherscan/makeEtherscanAddressURL.ts
@@ -10,6 +10,8 @@ export function makeEtherscanAddressURL(
       return `https://etherscan.io/address/${address}`;
     case 5:
       return `https://goerli.etherscan.io/address/${address}`;
+    case 31337:
+      return `#`;
     default:
       assertNever(chainId);
   }

--- a/apps/council-ui/src/etherscan/makeEtherscanTransactionURL.ts
+++ b/apps/council-ui/src/etherscan/makeEtherscanTransactionURL.ts
@@ -10,6 +10,8 @@ export function makeEtherscanTransactionURL(
       return `https://etherscan.io/tx/${transactionHash}`;
     case 5:
       return `https://goerli.etherscan.io/tx/${transactionHash}`;
+    case 31337:
+      return `#`;
     default:
       assertNever(chainId);
   }

--- a/apps/council-ui/src/provider.ts
+++ b/apps/council-ui/src/provider.ts
@@ -3,9 +3,26 @@ import { allChains, ChainProviderFn, configureChains } from "wagmi";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 
+const supportedChainIds = Object.keys(councilConfigs);
+
 const configuredChains = allChains.filter((chain) => {
-  return Object.keys(councilConfigs).includes(`${chain.id}`);
+  // Wagmi has 2 chains with the 31337 id, Hardhat and Foundry. Calling
+  // configureChains with 2 chains using the same id will cause errors, so we
+  // filter them out here to make room for a custom one.
+  return chain.id !== 31337 && supportedChainIds.includes(`${chain.id}`);
 });
+
+// Add a general Localhost chain for 31337
+if (supportedChainIds.includes("31337")) {
+  configuredChains.push({
+    id: 31337,
+    name: "Localhost",
+    network: "localhost",
+    rpcUrls: {
+      default: process.env.NEXT_PUBLIC_LOCAL_RPC_URL || "http://127.0.0.1:8545",
+    },
+  });
+}
 
 const configuredProviders = configuredChains.map((chain) => {
   if (chain.id === 1) {
@@ -33,18 +50,10 @@ const configuredProviders = configuredChains.map((chain) => {
   }
 
   if (chain.id === 31337) {
-    const localURL = process.env.NEXT_PUBLIC_LOCAL_RPC_URL;
-    if (!localURL) {
-      console.error(
-        "Chain ID 31337 (hardhat/foundry) exists in council.config.ts, but no provider was given, see .env",
-      );
-    }
-    const localRpcUrl = process.env.NEXT_PUBLIC_LOCAL_RPC_URL;
-    if (localRpcUrl) {
-      return jsonRpcProvider({
-        rpc: () => ({ http: localRpcUrl }),
-      });
-    }
+    const provider = jsonRpcProvider({
+      rpc: () => ({ http: chain.rpcUrls.default }),
+    });
+    return provider;
   }
 }) as ChainProviderFn[]; // safe to cast
 

--- a/apps/council-ui/src/provider.ts
+++ b/apps/council-ui/src/provider.ts
@@ -12,8 +12,11 @@ const configuredChains = allChains.filter((chain) => {
   return chain.id !== 31337 && supportedChainIds.includes(`${chain.id}`);
 });
 
-// Add a general Localhost chain for 31337
-if (supportedChainIds.includes("31337")) {
+// Add a general Localhost chain for 31337 if in development
+if (
+  supportedChainIds.includes("31337") &&
+  process.env.NODE_ENV === "development"
+) {
   configuredChains.push({
     id: 31337,
     name: "Localhost",

--- a/apps/council-ui/src/ui/vaults/vestingVault/VestingVaultProfileCard.tsx
+++ b/apps/council-ui/src/ui/vaults/vestingVault/VestingVaultProfileCard.tsx
@@ -55,11 +55,6 @@ export function VestingVaultProfileCard({
     delegateIsGSCMember,
   } = data || {};
 
-  console.log({
-    profileAddress,
-    accountDelegate: accountDelegate?.address,
-  });
-
   return (
     <VaultProfileCard
       address={address}

--- a/packages/council-deploy/package.json
+++ b/packages/council-deploy/package.json
@@ -45,19 +45,23 @@
     "typescript": "^4.7.4"
   },
   "scripts": {
-    "start-node": "rm src/deployments/localhost.deployments.json && hardhat node",
+    "start-node": "rm -f src/deployments/localhost.deployments.json && hardhat node",
     "build": "parcel build",
     "watch": "parcel watch",
     "load-contracts": "sh scripts/load-contracts.sh",
     "mainnet:deploy-contracts": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/promptDeploy.ts --network mainnet --no-compile",
+    "mainnet:deploy-airdrop": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/airdrop/promptDeployAirdrop.ts --network mainnet --no-compile",
+    "mainnet:mint-voting-tokens": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/votingToken/promptMintFromListOfVotingTokens.ts --network mainnet --no-compile",
+    "mainnet:deposit-voting-tokens": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/vaults/lockingVault/promptChooseLockingVaultAndDepositTokens.ts --network mainnet --no-compile",
     "goerli:deploy-contracts": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/promptDeploy.ts --network goerli --no-compile",
-    "local:deploy-contracts": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/promptDeploy.ts --network localhost --no-compile",
+    "goerli:deploy-airdrop": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/airdrop/promptDeployAirdrop.ts --network goerli --no-compile",
     "goerli:propose-remove-vesting-vault": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/coreVoting/proposals/createProposalRemoveVestingVault.ts --network goerli --no-compile",
     "goerli:propose-one-second-timelock-wait-time": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/coreVoting/proposals/createProposalSetWaitTime.ts --network goerli --no-compile",
     "goerli:mint-voting-tokens": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/votingToken/promptMintFromListOfVotingTokens.ts --network goerli --no-compile",
-    "goerli:deposit-voting-tokens-into-locking-vault": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/vaults/lockingVault/promptChooseLockingVaultAndDepositTokens.ts --network goerli --no-compile",
-    "mainnet:deploy-airdrop": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/airdrop/promptDeployAirdrop.ts --network mainnet --no-compile",
-    "goerli:deploy-airdrop": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/airdrop/promptDeployAirdrop.ts --network goerli --no-compile",
-    "local:deploy-airdrop": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/airdrop/promptDeployAirdrop.ts --network localhost --no-compile"
+    "goerli:deposit-voting-tokens": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/vaults/lockingVault/promptChooseLockingVaultAndDepositTokens.ts --network goerli --no-compile",
+    "local:deploy-contracts": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/promptDeploy.ts --network localhost --no-compile",
+    "local:deploy-airdrop": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/airdrop/promptDeployAirdrop.ts --network localhost --no-compile",
+    "local:mint-voting-tokens": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/votingToken/promptMintFromListOfVotingTokens.ts --network localhost --no-compile",
+    "local:deposit-voting-tokens": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx hardhat run src/vaults/lockingVault/promptChooseLockingVaultAndDepositTokens.ts --network localhost --no-compile"
   }
 }

--- a/packages/council-deploy/src/deployCouncil.ts
+++ b/packages/council-deploy/src/deployCouncil.ts
@@ -115,7 +115,7 @@ export async function deployCouncil(signer: Signer): Promise<
     // the GSC does not have a voting power requirement to submit a proposal
     gscCoreVotingAddress: gscCoreVoting.address,
     // can execute a proposal 10 blocks after it gets created
-    lockDuration: 10,
+    lockDuration: 0,
     // can still vote on a proposal for this many blocks after it unlocks
     extraVotingTime: 300000, // ~ 1 week on goerli
   });

--- a/packages/council-deploy/src/votingToken/promptMint.ts
+++ b/packages/council-deploy/src/votingToken/promptMint.ts
@@ -34,9 +34,7 @@ export async function promptMint(
   console.log("Mint submitted, waiting 1 confirmation...");
   const minedTx = await tx.wait(1);
 
-  console.log(
-    `Mint confirmed! View on etherscan: ${makeGoerliTransactionUrl(tx.hash)}`,
-  );
+  console.log(`Mint confirmed! ${tx.hash}`);
 
   return minedTx;
 }


### PR DESCRIPTION
- Made more `@council/deploy` scripts chain agnostic and added scripts to the `package.json`
- Added a Localhost network to the `council-ui` when `NODE_ENV` is `"development"`
- Edited the deploy args for `deployCouncil` when deploying to `31337` to reduce block numbers